### PR TITLE
fixed `auto-virtualenv--project-root-vc`

### DIFF
--- a/auto-virtualenv.el
+++ b/auto-virtualenv.el
@@ -73,9 +73,9 @@
 
 (defun auto-virtualenv--project-root-vc ()
   "Return vc root if file is in version control"
-  (when (or
-         (vc-find-root (or (buffer-file-name) "") ".git")
-         (vc-find-root (or (buffer-file-name) "") ".hg"))))
+  (or
+   (vc-find-root (or (buffer-file-name) "") ".git")
+   (vc-find-root (or (buffer-file-name) "") ".hg")))
 
 
 (defun auto-virtualenv--project-root-traverse ()


### PR DESCRIPTION
`auto-virtualenvwrapper--project-root-vc` always return `nil` because no `then-forms` is given to  `when`.

References: [emacs manual:  Conditionals](https://www.gnu.org/software/emacs/manual/html_node/elisp/Conditionals.html)