### PR TITLE
Allow local virtual environment directories to be configurable

### DIFF
--- a/README.org
+++ b/README.org
@@ -64,6 +64,7 @@ To enable this feature, set ~auto-virtualenv-reload-lsp~ to ~t~ (the default set
 * Customization Options
 The package provides customizable options to adapt to your project structure:
 - ~auto-virtualenv-global-dirs~: Directories to search for virtual environments by project name.
+- ~auto-virtualenv-local-dirs~: Directories in the project root to search for virtual environments.
 - ~auto-virtualenv-python-project-files~: Files that identify a Python project (e.g., ~requirements.txt~, ~setup.py~).
 - ~auto-virtualenv-activation-hooks~: Hooks that trigger virtual environment activation (default: ~find-file-hook~ and ~projectile-after-switch-project-hook~).
 - ~auto-virtualenv-verbose~: Enable verbose output for debugging.
@@ -71,10 +72,12 @@ The package provides customizable options to adapt to your project structure:
 
 Example configuration:
 #+BEGIN_SRC emacs-lisp
-(setq auto-virtualenv-global-dirs
-      '("~/.virtualenvs/" "~/.pyenv/versions/" "~/.envs/" "~/.conda/" "~/.conda/envs/"))
-(setq auto-virtualenv-python-project-files
-      '("requirements.txt" "Pipfile" "pyproject.toml" "setup.py" "manage.py" "tox.ini" ".flake8"))
+  (setq auto-virtualenv-global-dirs
+        '("~/.virtualenvs/" "~/.pyenv/versions/" "~/.envs/" "~/.conda/" "~/.conda/envs/"))
+  (setq auto-virtualenv-global-dirs
+        '(".venv" "venv"))
+  (setq auto-virtualenv-python-project-files
+        '("requirements.txt" "Pipfile" "pyproject.toml" "setup.py" "manage.py" "tox.ini" ".flake8"))
 #+END_SRC
 
 * Related Projects and Inspirations

--- a/auto-virtualenv.el
+++ b/auto-virtualenv.el
@@ -57,6 +57,12 @@
   :type '(repeat string)
   :group 'auto-virtualenv)
 
+(defcustom auto-virtualenv-local-dirs
+  '(".venv" "venv")
+  "List of local directories to search for virtual environments."
+  :type '(repeat string)
+  :group 'auto-virtualenv)
+
 (defcustom auto-virtualenv-python-project-files
   '("requirements.txt" "Pipfile" "pyproject.toml" "setup.py" "manage.py" "tox.ini" ".flake8" "pytest.ini"
     ".pre-commit-config.yaml" "environment.yml" "__init__.py")
@@ -116,11 +122,12 @@
 (defun auto-virtualenv-find-local-venv (project-root)
   "Check for a local virtual environment in PROJECT-ROOT. Return the path if found, otherwise nil."
   (auto-virtualenv--debug "Checking for local virtualenv in %s" project-root)
-  (let ((local-venv-path (or (expand-file-name ".venv" project-root)
-                             (expand-file-name "venv" project-root))))
-    (when (file-directory-p local-venv-path)
-      (auto-virtualenv--debug "Found local virtualenv at %s" local-venv-path)
-      local-venv-path)))
+  (cl-some (lambda (dir)
+             (let ((local-venv-path (expand-file-name dir project-root)))
+               (when (file-directory-p local-venv-path)
+                 (auto-virtualenv--debug "Found local virtualenv in %s" local-venv-path)
+                 local-venv-path)))
+           auto-virtualenv-local-dirs))
 
 (defun auto-virtualenv-find-global-venv (env-name)
   "Search for ENV-NAME in `auto-virtualenv-global-dirs`, only at top level of each directory."


### PR DESCRIPTION
I discovered an issue that `local-venv-path` will always be set to `project_root + ".venv"`.

When trying to address it I also make the local search paths to be configurable.